### PR TITLE
Scale down Download Plot Data button by 50%

### DIFF
--- a/online/index.html
+++ b/online/index.html
@@ -371,20 +371,20 @@
         .csv-download-link a {
             display: inline-flex;
             align-items: center;
-            gap: 8px;
-            padding: 10px 20px;
+            gap: 4px;
+            padding: 5px 10px;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             color: white;
             text-decoration: none;
-            border-radius: 8px;
-            font-size: 0.95em;
+            border-radius: 4px;
+            font-size: 0.475em;
             font-weight: 500;
             transition: all 0.3s ease;
-            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+            box-shadow: 0 1px 4px rgba(102, 126, 234, 0.3);
         }
         .csv-download-link a:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+            transform: translateY(-1px);
+            box-shadow: 0 2px 6px rgba(102, 126, 234, 0.4);
         }
         .csv-download-link svg {
             flex-shrink: 0;
@@ -2055,7 +2055,7 @@ window.pyProcessAudio = process_audio_if_ready
                 </div>
                 <div class="csv-download-link">
                     <a href="#" id="download-csv-btn" onclick="window.downloadCSV(); return false;">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
                             <polyline points="7,10 12,15 17,10"/>
                             <line x1="12" y1="15" x2="12" y2="3"/>


### PR DESCRIPTION
Reduced the size of the Download Plot Data button to make it less prominent since it's not a primary flow:
- Font size: 0.95em → 0.475em (50%)
- Padding: 10px 20px → 5px 10px (50%)
- Gap: 8px → 4px (50%)
- Border radius: 8px → 4px (50%)
- SVG icon: 16x16 → 8x8 (50%)
- Box shadow: scaled proportionally
- Hover transform: -2px → -1px (50%)