### PR TITLE
Add GitHub Actions workflow to deploy site files to gh-pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'index.html'
+      - 'SJPlot.py'
+      - 'online/**'
+      - '.github/workflows/deploy-gh-pages.yml'
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup deployment directory
+        run: |
+          mkdir -p deploy
+          cp index.html deploy/
+          cp SJPlot.py deploy/
+          cp -r online deploy/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy
+          publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
Automatically sync index.html, SJPlot.py, and online/ directory to the gh-pages branch whenever they change on main. This keeps only site files published while excluding project files like README, images, etc.